### PR TITLE
Create FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,15 @@
+# These are supported funding model platforms
+
+github: [AndresMarulanda10]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+polar: # Replace with a single Polar username
+buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
+thanks_dev: # Replace with a single thanks.dev username
+custom: [BinancePayID:303274176, https://donate.stripe.com/00wdR82QZf690Bc3U84c80V]


### PR DESCRIPTION
This pull request adds a `.github/FUNDING.yml` file to configure supported funding model platforms for the repository. It includes various platforms where users can contribute financially to the project.

### Key change:

* [`.github/FUNDING.yml`](diffhunk://#diff-07985fdcade0e64d11482724879a644f07879ba61b8fb6c6119e1b1902b72ae4R1-R15): Added a funding configuration file with support for multiple platforms, including GitHub Sponsors, Patreon, Open Collective, Ko-fi, and others. Custom funding options such as Binance Pay and Stripe donation links are also included.